### PR TITLE
Fixed issue with boto object.put

### DIFF
--- a/sqlalchemy-s3sqlite/dialect.py
+++ b/sqlalchemy-s3sqlite/dialect.py
@@ -107,7 +107,7 @@ class S3SQLiteDialect(SQLiteDialect_pysqlite):
                 )
 
                 s3_object = s3.Object(bucketname, self._remote_dbname)
-                result = s3_object.put('rb', Body=bytesIO)
+                result = s3_object.put(Body=bytesIO)
                 logging.debug("Saved to remote DB!")
         except Exception as e:
             logging.debug(e)


### PR DESCRIPTION
There seems to be an issue with the latest version of boto that results in the `put` call to S3 failing with the error message:

`put_object() only accepts keyword arguments.`

This change seems to fix it for me.